### PR TITLE
ADD: Setup basic issue templates for bugs, features and documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,49 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug:**
+
+A clear and concise description of what the bug is.
+
+**To Reproduce:**
+
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior:**
+
+A clear description of what you expected to happen.
+
+**Actual Behavior:**
+
+A clear description of what actually happened.
+
+**Screenshots:**
+
+If applicable, add screenshots to help explain your problem.
+
+**Environment:**
+ - OS: [e.g. Windows]
+ - Version [e.g. 1.0.1]
+ - Any Additional Information
+
+**Additional context:**
+
+Add any other context about the problem here.
+
+**Logs**
+
+Include any relevant logs or error messages.
+
+**Possible Fix**
+
+If you have any ideas on how to fix or address the issue, please let us know.

--- a/.github/ISSUE_TEMPLATE/documentation_improvement.md
+++ b/.github/ISSUE_TEMPLATE/documentation_improvement.md
@@ -1,0 +1,36 @@
+---
+name: Documentation Improvement
+about: Suggest an idea for improving the documentation for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Documentation Location**
+
+Provide the location of the documentation issue.
+
+**Type of Documentation Issue**
+
+Specify if it's a correction, clarification, enhancement, or other.
+
+**Issue Description**
+
+Describe the issue or improvement you are suggesting.
+
+**Suggested Changes**
+
+If applicable, suggest specific changes to address the issue.
+
+**Additional Context**
+
+Add any additional context, screenshots, or information that may help understand the documentation issue better.
+
+**Proposed Solution**
+
+If you have a proposed solution, describe it here.
+
+**Additional Comments**
+
+Is there anything else you would like to add? Any additional information or thoughts about the documentation improvement.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,28 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**If this feature request related to a problem? Please describe.**
+
+Provide a description of the problem and how this feature would solve the problem.
+
+**Alternatives Considered If Applicable**
+
+Describe any alternative solutions or features you've considered.
+
+**Rationale**
+
+Explain why this feature would be beneficial and how it aligns with the goals of the project.
+
+**Implementation Ideas**
+
+Provide any ideas or suggestions you may have for implementing this feature. This could include high-level technical details, user interface considerations, or any other relevant information.
+
+**Additional Context**
+
+Add any other context, screenshots, or information that may help understand the feature request better.


### PR DESCRIPTION
This pull requests adds basic Issue templates for bug report, feature request and documentation.

More information can be found [here](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository).