### PR TITLE
Fix for datetime assertion in unit test

### DIFF
--- a/job_monitoring_app/backend/tests/routers/test_events.py
+++ b/job_monitoring_app/backend/tests/routers/test_events.py
@@ -60,7 +60,7 @@ def test_update_event(app_client, job_for_random_user_with_api_key, db):
     event_id = response.json()["id"]
 
     # Capture current time before update
-    current_time_before_update = datetime.datetime.utcnow()
+    current_time_before_update = datetime.datetime.now()
 
     # Prepare data for updating the event
     updated_event_data = {
@@ -90,7 +90,7 @@ def test_update_event(app_client, job_for_random_user_with_api_key, db):
     assert update_response.status_code == 200
 
     # Capture current time after update
-    current_time_after_update = datetime.datetime.utcnow()
+    current_time_after_update = datetime.datetime.now()
 
     # # Verify the updated event attributes
 
@@ -103,5 +103,9 @@ def test_update_event(app_client, job_for_random_user_with_api_key, db):
 
     assert update_response.json()["job_id"] == job.id
     assert update_response.json()["created_at"] == response.json()["created_at"]
+
+    print(current_time_before_update)
+    print(update_datetime)
+    print(current_time_after_update)
 
     assert current_time_before_update <= update_datetime <= current_time_after_update


### PR DESCRIPTION
# Overview
<!-- _What is the purpose of this pull request?_ -->
A test that did not fail upon merge to main is now failing.

# Implementation
<!-- 
_What items were implemented?_
_What are their key components and functionality?_
_What does this add to the overall project?_
_How do you use this new functionality? (if applicable)_
-->
We previously used datetime.utcnow() and switching to datetime.now() seemed to fix it.

# Testing
<!--
_How was this feature tested?_
_What automated tests were used?_
_What manual tests were used?_
_Where are these documented?_
-->
Run test_update_event and you should see no errors.

# Problems Faced
<!-- _Did you run into any problems, if so how did you resolve them? -->

# Notes
<!-- 
_Any screenshots/videos demonstrating the functioning of the changes made in this pull request?_
_Is there any other important notes related to this pull request?

-->
