### PR TITLE
Fix cypress tests

### DIFF
--- a/job_monitoring_app/frontend/cypress/e2e/apikeys.feature
+++ b/job_monitoring_app/frontend/cypress/e2e/apikeys.feature
@@ -5,7 +5,7 @@ Feature: API Keys
     And user clicks "/login" href button
     Then user should be on "/login" page
     When user fills "Email" with "botimage@gmail.com"
-    And user fills "Password" with "abc"
+    And user fills "Password" with "abcdefg"
     And user clicks "login" datatestid button
     Then user should see "Login successful. Redirecting..."
     When user waits

--- a/job_monitoring_app/frontend/cypress/e2e/dashboard.feature
+++ b/job_monitoring_app/frontend/cypress/e2e/dashboard.feature
@@ -5,7 +5,7 @@ Feature: Dashboard
     And user clicks "/login" href button
     Then user should be on "/login" page
     When user fills "Email" with "botimage@gmail.com"
-    And user fills "Password" with "abc"
+    And user fills "Password" with "abcdefg"
     And user clicks "login" datatestid button
     Then user should see "Login successful. Redirecting..."
     When user waits


### PR DESCRIPTION
# Overview
<!-- _What is the purpose of this pull request?_ -->
2 out of 4 of our Cypress tests were failing due to not being able to find the users in the database.

# Implementation
<!-- 
_What items were implemented?_
_What are their key components and functionality?_
_What does this add to the overall project?_
_How do you use this new functionality? (if applicable)_
-->
Upon research I realized these tests did not need to be rewritten and instead it was a problem with seeding our db. I discovered that running 'python seed.py' does not seed our development database like I thought. Instead I found the file tasks.py in the backend directory that contains commands to seed, upgrade, drop, create, etc our dev db. 
Steps I took to fix the tests:
1. navigated to backend directory
3. ran ```python tasks.py db:dev:seed```
4. updated the password fields in the feature files to reflect the seeded passwords


# Testing
<!--
_How was this feature tested?_
_What automated tests were used?_
_What manual tests were used?_
_Where are these documented?_
-->
1. seed the dev database using the command above from tasks.py
2. run ```psql -U postgres```
3. run ```select * from users;``` to verify seeded users are in the users table
4. navigate to frontend directory and run ```npm run test:e2e``` to verify all tests pass (takes ~10 mins to run)

# Problems Faced
<!-- _Did you run into any problems, if so how did you resolve them? -->
I could not figure out how to seed the dev database, but the commands in tasks.py solved this issue. I will be posting those in our quickstart wiki page.

# Notes
<!-- 
_Any screenshots/videos demonstrating the functioning of the changes made in this pull request?_
_Is there any other important notes related to this pull request?

-->
See the quickstart wiki page for more info on tasks.py. Since no tests needed to be re-written this was really a 1 point issue instead of 3.