### PR TITLE
149 remove api key generation from provider

### DIFF
--- a/internal_servers/orthanc_reciever_agent.py
+++ b/internal_servers/orthanc_reciever_agent.py
@@ -7,6 +7,15 @@ import time
 import zipfile
 from internal_servers.orthanc_data_logging import OrthancStudyLogger
 
+import os
+from dotenv import load_dotenv
+
+base_project_dir = Path(__file__).parent.parent
+relative_env_path = base_project_dir / "job_monitoring_app/backend/.env.local"
+assert relative_env_path.exists(), f"Expected to find .env file at {relative_env_path}"
+load_dotenv(relative_env_path)
+
+API_KEY = os.environ.get("API_KEY")
 
 product_path = Path(__file__).parent.parent / "example_tool" / "brainmask_tool.py"
 assert product_path.exists()
@@ -264,7 +273,7 @@ def make_list_of_studies_to_process(
                     study_processed_dict[study_id] = OrthancStudyLogger(
                         hospital_id=1,
                         study_id=unique_study_id,
-                        tracker_api_key="epysCnrob7qQG4m8vdrYspDR66U",
+                        tracker_api_key=API_KEY,
                         study_config_file="hospital_job_configuration.json",
                     )
             else:

--- a/internal_servers/orthanc_reciever_agent.py
+++ b/internal_servers/orthanc_reciever_agent.py
@@ -16,6 +16,7 @@ assert relative_env_path.exists(), f"Expected to find .env file at {relative_env
 load_dotenv(relative_env_path)
 
 API_KEY = os.environ.get("API_KEY")
+EXAMPLE_OUTPUT_PATH = os.environ.get("EXAMPLE_OUTPUT_PATH")
 
 product_path = Path(__file__).parent.parent / "example_tool" / "brainmask_tool.py"
 assert product_path.exists()
@@ -370,4 +371,4 @@ def main(internal_data_path: Path):
 
 
 if __name__ == "__main__":
-    main(Path("/home/mbrzus/programming/002_ImagePro/example_tool/example_output"))
+    main(Path(EXAMPLE_OUTPUT_PATH))

--- a/job_monitoring_app/backend/app/dependencies.py
+++ b/job_monitoring_app/backend/app/dependencies.py
@@ -115,6 +115,20 @@ def get_current_user_from_token(
 get_api_key_from_header = APIKeyHeader(name=API_KEY_HEADER_NAME, auto_error=False)
 
 
+def get_current_admin(user=Depends(get_current_user_from_token)) -> User:
+    """
+    This function checks if the current user is an admin and returns the user if true.
+    If the user is not an admin, it raises an HTTPException with status code 401.
+    """
+    if user.role == UserRoleEnum.admin:
+        return user
+
+    raise HTTPException(
+        status_code=HTTP_401_UNAUTHORIZED,
+        detail="Not authorized",
+    )
+
+
 def get_current_provider(user=Depends(get_current_user_from_token)) -> User:
     """
     This function checks if the current user is a provider and returns the user if true.

--- a/job_monitoring_app/backend/conftest.py
+++ b/job_monitoring_app/backend/conftest.py
@@ -123,22 +123,6 @@ def random_hospital_user(db):
     return test_hospital_user
 
 
-@pytest.fixture
-def random_admin_user(db):
-    random_tag = get_next_user_count()
-    test_admin_user = services.create_user(
-        db,
-        schemas.UserCreate(
-            email=f"test-admin-user_{random_tag}@example.com",
-            password="abc",
-            first_name="first",
-            last_name="last",
-            role=UserRoleEnum.admin,
-        ),
-    )
-    return test_admin_user
-
-
 # Convenience fixture factory for generating multiple
 # users for a test. See https://stackoverflow.com/a/21590140
 @pytest.fixture

--- a/job_monitoring_app/backend/seed.py
+++ b/job_monitoring_app/backend/seed.py
@@ -366,6 +366,19 @@ USERS_DATA = [
         role=UserRoleEnum.provider,
         provider_id=1,
     ),
+    # Admins
+    dict(
+        email="admin1@admin.com",
+        password="abcdefg",
+        first_name="Admin1",
+        role=UserRoleEnum.admin,
+    ),
+    dict(
+        email="admin2@admin.com",
+        password="abcdefg",
+        first_name="Admin2",
+        role=UserRoleEnum.admin,
+    ),
 ]
 
 API_KEYS_DATA = [

--- a/job_monitoring_app/frontend/__tests__/apikeyindex.test.tsx
+++ b/job_monitoring_app/frontend/__tests__/apikeyindex.test.tsx
@@ -21,6 +21,14 @@ const testProvider: User = Object.freeze({
   role: "provider"
 });
 
+const testAdmin: User = Object.freeze({
+  id: 1,
+  first_name: "Admin",
+  last_name: "Admin",
+  email: "admin@gmail.com",
+  role: "admin"
+});
+
 jest.mock("@/data", () => ({
   __esModule: true,
   ...jest.requireActual("@/data")
@@ -59,7 +67,7 @@ describe("API Keys Page", () => {
   beforeEach(() => {
     jest.spyOn(data, "fetchCheckUserLoggedIn").mockImplementation(() =>
       Promise.resolve({
-        user: testProvider,
+        user: testAdmin,
         message: ""
       })
     );
@@ -76,7 +84,7 @@ describe("API Keys Page", () => {
         name: 'API Keys'
       })
     );
-    const text = await waitFor(() => screen.getByText('Manage API Keys for your provider account'));
+    const text = await waitFor(() => screen.getByText('Manage API Keys'));
 
     expect(heading).toBeInTheDocument();
     expect(text).toBeInTheDocument();
@@ -99,7 +107,7 @@ describe("API Keys Page", () => {
     expect(heading).toBeInTheDocument();
   });
 
-  describe("when user is provider", () => {
+  describe("when user is admin", () => {
     it("renders a list of API keys", async () => {
       const { getByTestId } = await act(async () =>
         render(<ApiKeys />, { wrapper: AuthContextProvider })
@@ -113,7 +121,7 @@ describe("API Keys Page", () => {
     });
   });
 
-  describe("when user is not provider", () => {
+  describe("when user is not admin", () => {
     beforeEach(() => {
       jest.spyOn(data, "fetchCheckUserLoggedIn").mockImplementation(() =>
         Promise.resolve({

--- a/job_monitoring_app/frontend/cypress/e2e/apikeys.feature
+++ b/job_monitoring_app/frontend/cypress/e2e/apikeys.feature
@@ -4,7 +4,7 @@ Feature: API Keys
     Given user is on the homepage
     And user clicks "/login" href button
     Then user should be on "/login" page
-    When user fills "Email" with "botimage@gmail.com"
+    When user fills "Email" with "admin1@admin.com"
     And user fills "Password" with "abcdefg"
     And user clicks "login" datatestid button
     Then user should see "Login successful. Redirecting..."

--- a/job_monitoring_app/frontend/cypress/e2e/apikeys.feature
+++ b/job_monitoring_app/frontend/cypress/e2e/apikeys.feature
@@ -13,7 +13,7 @@ Feature: API Keys
     Then user should be on "/apikeys" page
 
   Scenario: Create API Key Happy Route
-    Then user should see "Manage API Keys for your provider account"
+    Then user should see "Manage API Keys"
     When user fills "Note" with "My Key"
     And user clicks "submit" datatestid button
     Then user should see "Please copy this key for later. This is the only time you will see it."

--- a/job_monitoring_app/frontend/cypress/e2e/dashboard.feature
+++ b/job_monitoring_app/frontend/cypress/e2e/dashboard.feature
@@ -19,7 +19,3 @@ Feature: Dashboard
   Scenario: Analytics route
     When user clicks "/analytics" href button
     Then user should be on "/analytics" page
-
-  Scenario: API Keys Route
-    When user clicks "/apikeys" href button
-    Then user should be on "/apikeys" page

--- a/job_monitoring_app/frontend/src/components/Navbar.tsx
+++ b/job_monitoring_app/frontend/src/components/Navbar.tsx
@@ -108,7 +108,7 @@ const Navbar = (): JSX.Element => {
       to: "/apikeys",
       name: "Generate API Keys",
       id: "apikeys",
-      show: currentUser?.role === "provider"
+      show: currentUser?.role === "admin"
     }
   ];
 

--- a/job_monitoring_app/frontend/src/pages/apikeys/index.tsx
+++ b/job_monitoring_app/frontend/src/pages/apikeys/index.tsx
@@ -114,7 +114,7 @@ function ApiKeys() {
     <Container pt={12} maxW="container.lg">
       <Box mb={8}>
         <Heading>API Keys</Heading>
-        <Text>Manage API Keys for your provider account</Text>
+        <Text>Manage API Keys</Text>
       </Box>
 
       <VStack alignItems={"flex-start"} spacing={8}>
@@ -265,4 +265,4 @@ function ApiKeys() {
 /**
  * Export the ApiKeys component wrapped with the withAuthenticated higher-order component.
  */
-export default withAuthenticated(ApiKeys, ["provider"]);
+export default withAuthenticated(ApiKeys, ["admin"]);

--- a/job_monitoring_app/frontend/src/pages/dashboard.tsx
+++ b/job_monitoring_app/frontend/src/pages/dashboard.tsx
@@ -107,9 +107,9 @@ function Dashboard() {
       text: "API Integration",
       icon: <Icon as={IoAnalyticsSharp} color={"yellow.500"} w={5} h={5} />,
       iconBg: "yellow.100",
-      show: currentUser?.role === "provider",
+      show: currentUser?.role === "admin",
       link: "/apikeys",
-      description: "Generate API keys for your provider account"
+      description: "Generate API keys"
     }
   ];
 


### PR DESCRIPTION
# Overview
<!-- _What is the purpose of this pull request?_ -->
We no longer want providers to have the ability to generate api keys. We also need set the API key as an environment variable in the receiver agent

# Implementation
<!-- 
_What items were implemented?_
_What are their key components and functionality?_
_What does this add to the overall project?_
_How do you use this new functionality? (if applicable)_
-->
The following was implemented:
- removal of 'Generate API Keys' from frontend for providers
- unless you are a logged in admin you cannot navigate to /apikeys
- new tests that verify trying to navigate to /apikeys with a hospital or provider role throws a 401
- api key is now pulled from environment file in receiver agent

# Testing
<!--
_How was this feature tested?_
_What automated tests were used?_
_What manual tests were used?_
_Where are these documented?_
-->
This was manually tested via docker compose and spinning up Orthancs locally. I was able to log in and kickoff a study in the agent. Everything worked as it should.
I logged in as a provider and a hospital user and verified I could not access the /apikeys page.
Cypress tests were updated and all pass as well as frontend and backend.

# Problems Faced
<!-- _Did you run into any problems, if so how did you resolve them? -->

# Notes
<!-- 
_Any screenshots/videos demonstrating the functioning of the changes made in this pull request?_
_Is there any other important notes related to this pull request?

-->
Current provider view:
<img width="400" alt="Screenshot 2024-03-28 at 10 33 52 PM" src="https://github.com/uiowaSEP2024/002_ImagePro/assets/57544141/ba695185-49c4-43c5-aec3-ac67b04a0e2a">

Current admin view:
<img width="400" alt="Screenshot 2024-03-28 at 10 34 39 PM" src="https://github.com/uiowaSEP2024/002_ImagePro/assets/57544141/aa1dc158-80f3-4588-9266-2f1b6615efea">
